### PR TITLE
Release v1.1.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convivainc/browser-tracker-core",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Types file reference for Browser Tracker Core Module",
   "main": "index.umd.min.d.ts",
   "types": "index.umd.min.d.ts",
@@ -10,7 +10,7 @@
   "author": "Conviva Inc",
   "license": "MIT",
   "dependencies": {
-    "@convivainc/tracker-core": "^1.1.18"
+    "@convivainc/tracker-core": "1.1.19"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR prepares the **1.1.25** release of `@convivainc/browser-tracker-core`.

### Changes

- `package.json` version bump `1.1.24 → 1.1.25`
- `@convivainc/tracker-core` dep pinned to exact `1.1.19` (companion release in [`Conviva/conviva-eco-js-tracker-core#4`](https://github.com/Conviva/conviva-eco-js-tracker-core/pull/4))
- `index.umd.min.d.ts` refreshed from current source build (content unchanged this round)

No README / CHANGELOG / AGENTS.md changes this round — types-only package.

### Related

Part of the DPI v2.2.0 / Replay v1.0.4 release train.